### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/components/shared/Slide-Corporativo.tsx
+++ b/components/shared/Slide-Corporativo.tsx
@@ -9,7 +9,7 @@ export function SlideCorporativo({ isActive = true, slide }: SLIDE_CARD_PROPS) {
     slide
 
   return (
-    <div aria-label={title.replace("\n", " ")} aria-hidden={!isActive}>
+    <div aria-label={title.replace(/\n/g, " ")} aria-hidden={!isActive}>
       <div className="flex flex-col rounded-2xl sm:flex-row">
         {/* Imagen */}
         <div className="relative h-52 w-full shrink-0 sm:h-auto sm:w-1/2">


### PR DESCRIPTION
Potential fix for [https://github.com/zifherx/web-sai/security/code-scanning/2](https://github.com/zifherx/web-sai/security/code-scanning/2)

Use a global replacement so all newline occurrences are normalized, not just the first one.

Best fix in this file: update line 12 in `components/shared/Slide-Corporativo.tsx` from string-pattern `replace("\n", " ")` to regex global replacement `replace(/\n/g, " ")`. This preserves existing behavior while correctly handling multiple newlines in `title`. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
